### PR TITLE
reorder binding initialization, "forward decalare" bindings, write test

### DIFF
--- a/pytests/xmol/test_no_cpp_signatures.py
+++ b/pytests/xmol/test_no_cpp_signatures.py
@@ -1,0 +1,166 @@
+
+import inspect
+import os
+import re
+import pyxmolpp2
+
+
+def get_full_class_name(klass):
+    return klass.__module__ + "." + klass.__name__
+
+
+def has_no_cpp_type_in_signature(docstring):
+    signature_regex = r"(\s*\d+\.)?(\s*{name})?\s*\((?P<args>[^\(\)]*)\)\s*->\s*(?P<rtype>[^\(\)]+)\s*".format(name="\w+")
+    signatures = "\n".join(filter(lambda line: re.match(signature_regex,line),docstring.split("\n")))
+    result = signatures.find("::") == -1
+    return result
+
+def get_function_signature(func, strip_module_name=True, module_name=None, klass_name=None):
+    name = func.__name__
+    try:
+        signature_regex = r"(\s*(?P<overload>\d+).)?\s*{name}\s*\((?P<args>[^\(\)]*)\)\s*->\s*(?P<rtype>[^\(\)]+)\s*".format(name=name)
+        doc_lines = func.__doc__
+        for line in doc_lines.split("\n"):
+            if strip_module_name and hasattr(func, "__module__") and func.__module__ is not None:
+                line = line.replace(func.__module__+".", "")
+            m = re.match(signature_regex, line)
+            if m:
+                args = m.group("args")
+                rtype = m.group("rtype")
+                overload = m.group("overload")
+                if overload:
+                    full_name = func.__name__
+                    print("WARNING:", "Using first found overload for", full_name)
+                # print(args, rtype)
+                return name, args, rtype
+        # print("Can't find pybind11 signature string in __doc__", func.__name__, func.__doc__)
+        return None
+    except AttributeError:
+        return name, "*args, **kwargs", None
+
+
+def get_property_type(prop, module_name):
+
+    getter_rtype = "None"
+    setter_args = "None"
+
+    strip_module_name = module_name is not None
+
+    for line in prop.fget.__doc__.split("\n"):
+        if strip_module_name:
+            line = line.replace(module_name + ".", "")
+        m = re.match(r"\s*\((?P<args>[^\(\)]*)\)\s*->\s*(?P<rtype>[^\(\)]+)\s*", line)
+        if m:
+            getter_rtype = m.group("rtype")
+            break
+
+    if prop.fset is not None:
+        for line in prop.fset.__doc__.split("\n"):
+            if strip_module_name:
+                line = line.replace(module_name + ".", "")
+            m = re.match(r"\s*\((?P<args>[^\(\)]*)\)\s*->\s*(?P<rtype>[^\(\)]+)\s*", line)
+            if m:
+                args = m.group("args")
+                # replace first argument with self
+                setter_args = ",".join(["self"]+args.split(",")[1:])
+                break
+
+    return getter_rtype, setter_args
+
+
+def check_free_function(func):
+    assert has_no_cpp_type_in_signature(func.__doc__)
+
+
+def check_class(klass):
+    assert inspect.isclass(klass)
+
+
+    docstrings = []
+    fields = []
+    properties = []
+    methods = []
+
+    for name, member in inspect.getmembers(klass):
+        # print(name, "::", member)
+
+        if inspect.ismemberdescriptor(member):
+            pass  # print("Method desc",  name, "::", member)
+        elif inspect.isroutine(member):
+            methods.append(member)
+        elif inspect.ismemberdescriptor(member):
+            pass  # print("mem decs",  name, "::", member)
+
+        elif isinstance(member,property):
+            # print("property", name, "::", member)
+            properties.append((name,member))
+        elif name == "__doc__":
+            if member is not None:
+                docstrings.append(member)
+        elif name in ["__class__","__module__"]:
+            pass
+        else:
+            pass # print("Unknown type", name, "::", member)
+
+
+    for field in fields:
+        print("FIELD", field.__doc__)
+
+    # write properties
+    for prop_name, prop in properties:
+
+        T1, T2 = get_property_type(prop, module_name=klass.__module__)
+
+        assert has_no_cpp_type_in_signature(prop.fget.__doc__)
+
+        if T2 != "None":
+            assert has_no_cpp_type_in_signature(prop.fset.__doc__)
+
+
+    for method in methods:
+        signature = get_function_signature(method)
+        if signature:
+            assert has_no_cpp_type_in_signature(method.__doc__)
+
+
+def check_module(module, main_module=None):
+    if main_module is None:
+        main_module = module
+    print("Processing", module)
+
+
+    docstrings = []
+    free_functions = []
+    classes = []
+    submodules = []
+
+    for name, member in inspect.getmembers(module):
+        # print(name, "::", member)
+        if inspect.ismodule(member):
+            submodules.append(member)
+        elif inspect.isbuiltin(member) or inspect.isfunction(member):
+            free_functions.append(member)
+        elif inspect.isclass(member) or inspect.isclass(member):
+            classes.append(member)
+        elif name == "__doc__":
+            docstrings.append(member)
+        elif name in ["__file__", "__loader__", "__name__", "__package__", "__spec__"]:
+            pass
+        else:
+            pass # print("Unknown type", name,"::",member)
+
+    for klass in classes:
+        check_class(klass)
+
+    for func in free_functions:
+        check_free_function(func)
+
+    # declare variables
+
+    for submodule in submodules:
+        check_module(submodule, main_module=main_module)
+
+def test_no_cpp_types_in_signatures():
+    check_module(module=pyxmolpp2)
+
+

--- a/pyxmolpp/geometry/Transformation3d.cpp
+++ b/pyxmolpp/geometry/Transformation3d.cpp
@@ -9,7 +9,12 @@ using namespace xmol::geometry;
 
 void pyxmolpp::geometry::init_Transformation3d(pybind11::module& geometry) {
 
-  py::class_<Translation3d>(geometry,"Translation3d")
+  auto&& pyTranslation3d = py::class_<Translation3d>(geometry,"Translation3d");
+  auto&& pyUniformScale3d = py::class_<UniformScale3d>(geometry,"UniformScale3d");
+  auto&& pyRotation3d = py::class_<Rotation3d>(geometry,"Rotation3d");
+  auto&& pyTransformation3d = py::class_<Transformation3d>(geometry,"Transformation3d");
+
+  pyTranslation3d
       .def(py::init<>())
       .def(py::init<XYZ>())
       .def("transform",&Translation3d::transform)
@@ -18,7 +23,7 @@ void pyxmolpp::geometry::init_Transformation3d(pybind11::module& geometry) {
       .def(py::self * py::self)
       ;
 
-  py::class_<UniformScale3d>(geometry,"UniformScale3d")
+  pyUniformScale3d
       .def(py::init<>())
       .def(py::init<double>())
       .def("transform",&UniformScale3d::transform)
@@ -29,7 +34,7 @@ void pyxmolpp::geometry::init_Transformation3d(pybind11::module& geometry) {
       .def(Translation3d() * py::self)
   ;
 
-  py::class_<Rotation3d>(geometry,"Rotation3d")
+  pyRotation3d
       .def(py::init<>())
       .def(py::init<XYZ,AngleValue>())
       .def("transform",&Rotation3d::transform)
@@ -43,7 +48,7 @@ void pyxmolpp::geometry::init_Transformation3d(pybind11::module& geometry) {
       .def(UniformScale3d() * py::self)
       ;
 
-  py::class_<Transformation3d>(geometry,"Transformation3d")
+  pyTransformation3d
       .def(py::init<>())
       .def(py::init<Rotation3d,Translation3d>())
       .def("transform",&Transformation3d::transform)

--- a/pyxmolpp/geometry/init.cpp
+++ b/pyxmolpp/geometry/init.cpp
@@ -1,9 +1,9 @@
 #include "init.h"
 
 void pyxmolpp::init_geometry(pybind11::module& m) {
-  geometry::init_alignment(m);
+  geometry::init_XYZ(m);
   geometry::init_AngleValue(m);
   geometry::init_basic(m);
   geometry::init_Transformation3d(m);
-  geometry::init_XYZ(m);
+  geometry::init_alignment(m);
 }

--- a/pyxmolpp/polymer/Atom.cpp
+++ b/pyxmolpp/polymer/Atom.cpp
@@ -8,59 +8,79 @@ void pyxmolpp::polymer::init_Atom(pybind11::module& polymer) {
   using namespace xmol::polymer;
   namespace py = pybind11;
 
-  py::class_<AtomName>(polymer, "AtomName")
+
+  auto&& pyAtomName = py::class_<AtomName>(polymer, "AtomName");
+  auto&& pyResidueName = py::class_<ResidueName>(polymer, "ResidueName");
+  auto&& pyChainName = py::class_<ChainName>(polymer, "ChainName");
+
+  auto&& pyAtom = py::class_<Atom>(polymer, "Atom");
+  auto&& pyResidue = py::class_<Residue>(polymer, "Residue");
+  auto&& pyChain = py::class_<Chain>(polymer, "Chain");
+  auto&& pyFrame = py::class_<Frame>(polymer, "Frame");
+
+  auto&& pyAtomSelection = py::class_<AtomSelection>(polymer, "AtomSelection");
+  auto&& pyResidueSelection = py::class_<ResidueSelection>(polymer, "ResidueSelection");
+  auto&& pyChainSelection = py::class_<ChainSelection>(polymer, "ChainSelection");
+
+  auto&& pyAtomSelectionRange = py::class_<xmol::selection::SelectionRange<Atom>>(polymer, "AtomSelectionRange");
+  auto&& pyResidueSelectionRange = py::class_<xmol::selection::SelectionRange<Residue>>(polymer, "ResidueSelectionRange");
+  auto&& pyChainSelectionRange = py::class_<xmol::selection::SelectionRange<Chain>>(polymer, "ChainSelectionRange");
+
+
+  pyAtomName
       .def(py::init<const std::string&>())
       .def_property_readonly("str", &AtomName::str)
       .def_property_readonly("value", &AtomName::value)
       .def("__str__",
-           [](const AtomName& name) { return '"' + name.str() + '"'; })
+          [](const AtomName& name) { return '"' + name.str() + '"'; })
       .def("__repr__", [](const AtomName& name) {
         return "<pyxmolpp2.polymer.AtomName \"" + name.str() + "\" at 0x" +
-               xmol::utils::string::int2hex((uint64_t)(std::addressof(name))) +
-               ">";
+            xmol::utils::string::int2hex((uint64_t)(std::addressof(name))) +
+            ">";
       });
 
-  py::class_<ResidueName>(polymer, "ResidueName")
+  pyResidueName
       .def(py::init<const std::string&>())
       .def_property_readonly("str", &ResidueName::str)
       .def_property_readonly("value", &ResidueName::value)
       .def("__str__",
-           [](const ResidueName& name) { return '"' + name.str() + '"'; })
+          [](const ResidueName& name) { return '"' + name.str() + '"'; })
       .def("__repr__", [](const ResidueName& name) {
         return "<pyxmolpp2.polymer.ResidueName \"" + name.str() + "\" at 0x" +
-               xmol::utils::string::int2hex((uint64_t)(std::addressof(name))) +
-               ">";
+            xmol::utils::string::int2hex((uint64_t)(std::addressof(name))) +
+            ">";
       });
 
-  py::class_<ChainName>(polymer, "ChainName")
+  pyChainName
       .def(py::init<const std::string&>())
       .def_property_readonly("str", &ChainName::str)
       .def_property_readonly("value", &ChainName::value)
       .def("__str__",
-           [](const ChainName& name) { return '"' + name.str() + '"'; })
+          [](const ChainName& name) { return '"' + name.str() + '"'; })
       .def("__repr__", [](const ChainName& name) {
         return "<pyxmolpp2.polymer.ChainName \"" + name.str() + "\" at 0x" +
-               xmol::utils::string::int2hex((uint64_t)(std::addressof(name))) +
-               ">";
+            xmol::utils::string::int2hex((uint64_t)(std::addressof(name))) +
+            ">";
       });
 
-  py::class_<Atom>(polymer, "Atom")
+
+  pyAtom
       .def_property_readonly("residue",
-                             static_cast<Residue& (Atom::*)()>(&Atom::residue),
-                             py::return_value_policy::reference)
+          static_cast<Residue& (Atom::*)()>(&Atom::residue),
+          py::return_value_policy::reference)
       .def_property("r", &Atom::r, &Atom::set_r,
-                    py::return_value_policy::reference_internal)
+          py::return_value_policy::reference_internal)
       .def_property_readonly("id", &Atom::id)
       .def_property_readonly("aId", &Atom::id)
       .def_property_readonly("name", &Atom::name)
       .def_property_readonly("aName", &Atom::name)
       .def_property_readonly("rId", [](Atom& a) { return a.residue().id(); })
       .def_property_readonly("rName",
-                             [](Atom& a) { return a.residue().name(); })
+          [](Atom& a) { return a.residue().name(); })
       .def_property_readonly(
           "cIndex", [](Atom& a) { return a.residue().chain().index(); })
       .def_property_readonly("cName",
-                             [](Atom& a) { return a.residue().chain().name(); })
+          [](Atom& a) { return a.residue().chain().name(); })
       .def_property_readonly(
           "fIndex", [](Atom& a) { return a.residue().chain().frame().index(); })
       .def_property_readonly(
@@ -72,13 +92,13 @@ void pyxmolpp::polymer::init_Atom(pybind11::module& polymer) {
           py::return_value_policy::reference)
       .def("__repr__", [](const Atom& atom) {
         return "<pyxmolpp2.polymer.Atom id=" + std::to_string(atom.id()) +
-               " name=\"" + atom.name().str() + "\" at 0x" +
-               xmol::utils::string::int2hex((uint64_t)(std::addressof(atom))) +
-               ">";
+            " name=\"" + atom.name().str() + "\" at 0x" +
+            xmol::utils::string::int2hex((uint64_t)(std::addressof(atom))) +
+            ">";
       });
   ;
 
-  py::class_<Residue>(polymer, "Residue")
+  pyResidue
       .def_property_readonly(
           "chain", static_cast<Chain& (Residue::*)()>(&Residue::chain),
           py::return_value_policy::reference)
@@ -90,93 +110,130 @@ void pyxmolpp::polymer::init_Atom(pybind11::module& polymer) {
       .def_property_readonly("name", &Residue::name)
       .def_property_readonly("rName", &Residue::name)
       .def_property_readonly("cIndex",
-                             [](Residue& r) { return r.chain().index(); })
+          [](Residue& r) { return r.chain().index(); })
       .def_property_readonly("cName",
-                             [](Residue& r) { return r.chain().name(); })
+          [](Residue& r) { return r.chain().name(); })
       .def_property_readonly(
           "fIndex", [](Residue& r) { return r.chain().frame().index(); })
       .def_property_readonly("asAtoms",
-                             [](Residue& residue) { return residue.asAtoms(); })
+          [](Residue& residue) { return residue.asAtoms(); })
       .def("emplace", &Residue::emplace, py::return_value_policy::reference,
-           py::arg("name"), py::arg("id"), py::arg("r"))
+          py::arg("name"), py::arg("id"), py::arg("r"))
       .def("__repr__", [](const Residue& residue) {
         return "<pyxmolpp2.polymer.Residue id=" + std::to_string(residue.id()) +
-               " name=\"" + residue.name().str() + "\" at 0x" +
-               xmol::utils::string::int2hex(
-                   (uint64_t)(std::addressof(residue))) +
-               ">";
+            " name=\"" + residue.name().str() + "\" at 0x" +
+            xmol::utils::string::int2hex(
+                (uint64_t)(std::addressof(residue))) +
+            ">";
       });
   ;
 
-  py::class_<Chain>(polymer, "Chain")
+  pyChain
       .def_property_readonly("frame",
-                             static_cast<Frame& (Chain::*)()>(&Chain::frame),
-                             py::return_value_policy::reference)
+          static_cast<Frame& (Chain::*)()>(&Chain::frame),
+          py::return_value_policy::reference)
       .def_property_readonly("index", &Chain::index)
       .def_property_readonly("cIndex", &Chain::index)
       .def_property_readonly("name", &Chain::name)
       .def_property_readonly("cName", &Chain::name)
       .def_property_readonly("fIndex",
-                             [](Chain& c) { return c.frame().index(); })
+          [](Chain& c) { return c.frame().index(); })
       .def_property_readonly("asResidues",
-                             [](Chain& chain) { return chain.asResidues(); })
+          [](Chain& chain) { return chain.asResidues(); })
       .def_property_readonly("asAtoms",
-                             [](Chain& chain) { return chain.asAtoms(); })
+          [](Chain& chain) { return chain.asAtoms(); })
       .def("emplace", &Chain::emplace, py::return_value_policy::reference,
-           py::arg("name"), py::arg("id"), py::arg("reserve") = 0)
+          py::arg("name"), py::arg("id"), py::arg("reserve") = 0)
       .def("__repr__", [](const Chain& chain) {
         return "<pyxmolpp2.polymer.Chain index=" +
-               std::to_string(chain.index()) + " name=\"" + chain.name().str() +
-               "\" at 0x" +
-               xmol::utils::string::int2hex((uint64_t)(std::addressof(chain))) +
-               ">";
+            std::to_string(chain.index()) + " name=\"" + chain.name().str() +
+            "\" at 0x" +
+            xmol::utils::string::int2hex((uint64_t)(std::addressof(chain))) +
+            ">";
       });
   ;
 
-  py::class_<Frame>(polymer, "Frame")
+  pyFrame
       .def(py::init<frameIndex_t>())
       .def_property_readonly("index", &Frame::index)
       .def_property_readonly("asChains",
-                             [](Frame& frame) { return frame.asChains(); })
+          [](Frame& frame) { return frame.asChains(); })
       .def_property_readonly("asResidues",
-                             [](Frame& frame) { return frame.asResidues(); })
+          [](Frame& frame) { return frame.asResidues(); })
       .def_property_readonly("asAtoms",
-                             [](Frame& frame) { return frame.asAtoms(); })
+          [](Frame& frame) { return frame.asAtoms(); })
       .def("emplace", &Frame::emplace, py::return_value_policy::reference,
-           py::arg("index"), py::arg("reserve") = 0)
+          py::arg("index"), py::arg("reserve") = 0)
       .def("__repr__", [](const Frame& frame) {
         return "<pyxmolpp2.polymer.Frame index=" +
-               std::to_string(frame.index()) + " at 0x" +
-               xmol::utils::string::int2hex((uint64_t)(std::addressof(frame))) +
-               ">";
+            std::to_string(frame.index()) + " at 0x" +
+            xmol::utils::string::int2hex((uint64_t)(std::addressof(frame))) +
+            ">";
       });
   ;
 
-  py::class_<AtomSelection>(polymer, "AtomSelection")
+//   .def("__iter__", [](xmol::selection::SelectionRange<Atom>& rng) -> sel& { return rng; })
+  pyAtomSelectionRange
+      .def("__next__", [](xmol::selection::SelectionRange<Atom>& rng) -> Atom& {
+            if (rng!=rng){
+              Atom& a = *rng;
+              ++rng;
+              return a;
+            }
+            throw py::stop_iteration();
+          },
+          py::return_value_policy::reference)
+      ;
+
+  pyResidueSelectionRange
+      .def("__next__", [](xmol::selection::SelectionRange<Residue>& rng) -> Residue& {
+            if (rng!=rng){
+              Residue& a = *rng;
+              ++rng;
+              return a;
+            }
+            throw py::stop_iteration();
+          },
+          py::return_value_policy::reference)
+      ;
+
+  pyChainSelectionRange
+      .def("__next__", [](xmol::selection::SelectionRange<Chain>& rng) -> Chain& {
+            if (rng!=rng){
+              Chain& a = *rng;
+              ++rng;
+              return a;
+            }
+            throw py::stop_iteration();
+          },
+          py::return_value_policy::reference)
+      ;
+
+  pyAtomSelection
       .def("__len__", [](AtomSelection& asel) { return asel.size(); })
       .def_property_readonly("size",
-                             [](AtomSelection& asel) { return asel.size(); })
+          [](AtomSelection& asel) { return asel.size(); })
       .def_property_readonly(
           "asChains", [](AtomSelection& aSel) { return aSel.asChains(); })
       .def_property_readonly(
           "asResidues", [](AtomSelection& aSel) { return aSel.asResidues(); })
       .def("__iter__",
-           [](AtomSelection& sel) {
-             return py::make_iterator(sel.begin(), sel.end());
-           },
-           py::keep_alive<0, 1>())
+          [](AtomSelection& sel) {
+            return sel.begin();
+          },
+          py::keep_alive<0, 1>())
       .def("__getitem__",
-           [](AtomSelection& sel, int index) -> Atom& { return sel[index]; },
-           py::return_value_policy::reference)
+          [](AtomSelection& sel, int index) -> Atom& { return sel[index]; },
+          py::return_value_policy::reference)
       .def("__repr__", [](const AtomSelection& selection) {
         return "<pyxmolpp2.polymer.AtomSelection size=" +
-               std::to_string(selection.size()) + " at 0x" +
-               xmol::utils::string::int2hex(
-                   (uint64_t)(std::addressof(selection))) +
-               ">";
+            std::to_string(selection.size()) + " at 0x" +
+            xmol::utils::string::int2hex(
+                (uint64_t)(std::addressof(selection))) +
+            ">";
       });
 
-  py::class_<ResidueSelection>(polymer, "ResidueSelection")
+  pyResidueSelection
       .def("__len__", &ResidueSelection::size)
       .def_property_readonly("size", &ResidueSelection::size)
       .def_property_readonly(
@@ -184,22 +241,22 @@ void pyxmolpp::polymer::init_Atom(pybind11::module& polymer) {
       .def_property_readonly(
           "asAtoms", [](ResidueSelection& rSel) { return rSel.asAtoms(); })
       .def("__iter__",
-           [](ResidueSelection& sel) {
-             return py::make_iterator(sel.begin(), sel.end());
-           },
-           py::keep_alive<0, 1>())
+          [](ResidueSelection& sel) {
+            return sel.begin();
+          },
+          py::keep_alive<0, 1>())
       .def("__getitem__", [](ResidueSelection& sel,
-                             int index) -> Residue& { return sel[index]; },
-           py::return_value_policy::reference)
+              int index) -> Residue& { return sel[index]; },
+          py::return_value_policy::reference)
       .def("__repr__", [](const ResidueSelection& selection) {
         return "<pyxmolpp2.polymer.ResidueSelection size=" +
-               std::to_string(selection.size()) + " at 0x" +
-               xmol::utils::string::int2hex(
-                   (uint64_t)(std::addressof(selection))) +
-               ">";
+            std::to_string(selection.size()) + " at 0x" +
+            xmol::utils::string::int2hex(
+                (uint64_t)(std::addressof(selection))) +
+            ">";
       });
 
-  py::class_<ChainSelection>(polymer, "ChainSelection")
+  pyChainSelection
       .def("__len__", &ChainSelection::size)
       .def_property_readonly("size", &ChainSelection::size)
       .def_property_readonly(
@@ -207,18 +264,18 @@ void pyxmolpp::polymer::init_Atom(pybind11::module& polymer) {
       .def_property_readonly(
           "asAtoms", [](ChainSelection& cSel) { return cSel.asAtoms(); })
       .def("__iter__",
-           [](ChainSelection& sel) {
-             return py::make_iterator(sel.begin(), sel.end());
-           },
-           py::keep_alive<0, 1>())
+          [](ChainSelection& sel) {
+            return sel.begin();
+          },
+          py::keep_alive<0, 1>())
       .def("__getitem__",
-           [](ChainSelection& sel, int index) -> Chain& { return sel[index]; },
-           py::return_value_policy::reference)
+          [](ChainSelection& sel, int index) -> Chain& { return sel[index]; },
+          py::return_value_policy::reference)
       .def("__repr__", [](const ChainSelection& selection) {
         return "<pyxmolpp2.polymer.ChainSelection size=" +
-               std::to_string(selection.size()) + " at 0x" +
-               xmol::utils::string::int2hex(
-                   (uint64_t)(std::addressof(selection))) +
-               ">";
+            std::to_string(selection.size()) + " at 0x" +
+            xmol::utils::string::int2hex(
+                (uint64_t)(std::addressof(selection))) +
+            ">";
       });
 }

--- a/pyxmolpp/pyxmolpp.cpp
+++ b/pyxmolpp/pyxmolpp.cpp
@@ -14,12 +14,12 @@ PYBIND11_MODULE(pyxmolpp2, m) {
     pyxmolpp::init_geometry(geometry);
   }
   {
-    pybind11::module pdb = m.def_submodule("pdb", "pyxmolpp2.pdb module");
-    pyxmolpp::init_pdb(pdb);
-  }
-  {
     pybind11::module polymer = m.def_submodule("polymer", "pyxmolpp2.polymer module");
     pyxmolpp::init_polymer(polymer);
+  }
+  {
+    pybind11::module pdb = m.def_submodule("pdb", "pyxmolpp2.pdb module");
+    pyxmolpp::init_pdb(pdb);
   }
 
 }


### PR DESCRIPTION
fixes #4 

tests is added to catch "::" in signature in generated doc strings