### PR TITLE
Tracking references

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,7 +36,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
-ColumnLimit:     80
+ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4

--- a/include/xmol/polymer/Atom.h
+++ b/include/xmol/polymer/Atom.h
@@ -31,8 +31,8 @@ public:
 
   bool is_deleted() const;
   void set_deleted();
-  const xmol::selection::Container<Atom>* parent() const;
-  xmol::selection::Container<Atom>* parent();
+  const Residue* parent() const;
+  Residue* parent();
 
 private:
   Atom(Residue& residue, AtomName name, atomId_t id, XYZ r);
@@ -48,12 +48,15 @@ private:
   bool m_deleted = false;
 };
 
-class Residue : public xmol::selection::Container<Atom> {
+class Residue : public xmol::selection::Container<Atom>, public xmol::selection::ObservableBy<ElementReference<Atom>> {
 public:
   Residue(const Residue& rhs);
   Residue(Residue&& rhs) noexcept;
   Residue& operator=(const Residue& rhs);
   Residue& operator=(Residue&& rhs) noexcept;
+  ~Residue(){
+    ObservableBy<ElementReference<Atom>>::notify_all(&ElementReference<Atom>::on_container_delete);
+  }
 
   const ResidueName& name() const;
   Residue& set_name(const ResidueName& value);
@@ -88,8 +91,15 @@ private:
   Residue(Chain& chain, ResidueName name, residueId_t id, int reserve = 0);
 
   friend class xmol::selection::Container<Residue>;
-
   friend class Chain;
+  friend class ElementReference<Atom>;
+
+  void add_reference(ElementReference<Atom>& aref){
+    ObservableBy<ElementReference<Atom>>::add_observer(aref);
+  }
+  void remove_reference(ElementReference<Atom>& aref){
+    ObservableBy<ElementReference<Atom>>::remove_observer(aref);
+  }
 
   ResidueName m_name;
   residueId_t m_id;

--- a/include/xmol/polymer/Atom_fwd.h
+++ b/include/xmol/polymer/Atom_fwd.h
@@ -108,23 +108,15 @@ public:
   bool is_valid() const{
     return ptr!=nullptr;
   }
-  T* get() const{
+  explicit operator T& () const{
     if (ptr==nullptr){
       throw std::runtime_error("Deleted element access through reference");
     }
-    return ptr;
+    return *ptr;
   }
 
-  T* operator->() const{
-    if (ptr==nullptr){
-      throw std::runtime_error("Deleted element access through reference");
-    }
-    return ptr;
-  }
-
-
-  void on_container_move(ptrdiff_t shift){
-    ptr+=shift;
+  void on_container_move(T* old_begin, T* new_begin){
+    ptr = new_begin + (ptr-old_begin);
   }
   void on_container_delete(){
     ptr = nullptr;

--- a/include/xmol/polymer/Atom_fwd.h
+++ b/include/xmol/polymer/Atom_fwd.h
@@ -55,6 +55,84 @@ using add_constness_as =
 using AtomName = xmol::utils::ShortAsciiString<4, false, detail::AtomNameTag>;
 using ResidueName = xmol::utils::ShortAsciiString<3, false, detail::ResidueNameTag>;
 using ChainName = xmol::utils::ShortAsciiString<1, false, detail::ChainNameTag>;
+
+template<typename T>
+class ElementReference{
+public:
+  explicit ElementReference(T& t): ptr(&t){
+    ptr->parent()->add_reference(*this);
+  }
+  ElementReference(const ElementReference& other) : ptr(other.ptr){
+    if (is_valid()){
+      ptr->parent()->add_reference(*this);
+    }
+  }
+  ElementReference(ElementReference&& other) {
+    if (other.is_valid()){
+      other.ptr->parent()->remove_reference(other);
+      other.ptr->parent()->add_reference(*this);
+    }
+    ptr=other.ptr;
+    other.ptr = nullptr;
+  }
+
+  ElementReference& operator=(const ElementReference& other) {
+    if (this==&other){return *this;}
+    if (is_valid()){
+      ptr->parent()->remove_reference(*this);
+    }
+    if (other.is_valid()){
+      other.ptr->parent()->add_reference(*this);
+    }
+    ptr = other.ptr;
+    return *this;
+  }
+  ElementReference& operator=(ElementReference&& other) {
+    if (this==&other){return *this;}
+    if (is_valid()){
+      ptr->parent()->remove_reference(*this);
+    }
+    if (other.is_valid()){
+      other.ptr->parent()->remove_reference(other);
+      other.ptr->parent()->add_reference(*this);
+    }
+    ptr=other.ptr;
+    other.ptr = nullptr;
+    return *this;
+  }
+  ~ElementReference(){
+    if (is_valid()){
+      ptr->parent()->remove_reference(*this);
+    }
+  }
+  bool is_valid() const{
+    return ptr!=nullptr;
+  }
+  T* get() const{
+    if (ptr==nullptr){
+      throw std::runtime_error("Deleted element access through reference");
+    }
+    return ptr;
+  }
+
+  T* operator->() const{
+    if (ptr==nullptr){
+      throw std::runtime_error("Deleted element access through reference");
+    }
+    return ptr;
+  }
+
+
+  void on_container_move(ptrdiff_t shift){
+    ptr+=shift;
+  }
+  void on_container_delete(){
+    ptr = nullptr;
+  }
+public:
+  T* ptr;
+};
+
 }
 }
 

--- a/pytests/xmol/polymer/test_Atom.py
+++ b/pytests/xmol/polymer/test_Atom.py
@@ -258,10 +258,26 @@ def test_range_exceptions():
         x = frame.asChains[-nchains-1]
 
 
-def test_tracking_refernces():
+def test_tracking_atom_refernces():
 
     frame = make_polyglycine([("A",1)])
     last_atom = frame.asAtoms[-1]  # store reference to Atom in python variable
     frame = None                   # release the reference to Frame and cause cascade deletion of everything
     with pytest.raises(Exception):
         last_atom.name             # access to destroyed elements is prohibited, exception raised
+
+
+def test_tracking_residue_refernces():
+
+    frame = make_polyglycine([("A",1)])
+    last_residue = frame.asResidues[-1]  # store reference to Atom in python variable
+    frame = None                   # release the reference to Frame and cause cascade deletion of everything
+    with pytest.raises(Exception):
+        last_residue.name             # access to destroyed elements is prohibited, exception raised
+
+def test_tracking_chain_refernces():
+    frame = make_polyglycine([("A",1)])
+    last_chain = frame.asChains[-1]  # store reference to Atom in python variable
+    frame = None                   # release the reference to Frame and cause cascade deletion of everything
+    with pytest.raises(Exception):
+        last_chain.name             # access to destroyed elements is prohibited, exception raised

--- a/pytests/xmol/polymer/test_Atom.py
+++ b/pytests/xmol/polymer/test_Atom.py
@@ -257,3 +257,11 @@ def test_range_exceptions():
     with pytest.raises(OutOfRangeChainSelection):
         x = frame.asChains[-nchains-1]
 
+
+def test_tracking_refernces():
+
+    frame = make_polyglycine([("A",1)])
+    last_atom = frame.asAtoms[-1]  # store reference to Atom in python variable
+    frame = None                   # release the reference to Frame and cause cascade deletion of everything
+    with pytest.raises(Exception):
+        last_atom.name             # access to destroyed elements is prohibited, exception raised

--- a/src/xmol/polymer/Atom.cpp
+++ b/src/xmol/polymer/Atom.cpp
@@ -114,7 +114,7 @@ Atom& Residue::emplace(AtomName name, atomId_t id, XYZ r) {
 }
 
 Atom& Residue::emplace(const Atom& atom) {
-  auto& a = Container<Atom>::emplace(atom);
+  auto& a = Container<Atom>::emplace(Atom(atom));
   a.m_residue = this;
   return a;
 }
@@ -218,7 +218,7 @@ Residue& Chain::emplace(ResidueName name, residueId_t id, int reserve) {
 
 Residue& Chain::emplace(const Residue& residue) {
   m_lookup_table.emplace(residue.id(), size());
-  auto& res = Container<Residue>::emplace(residue);
+  auto& res = Container<Residue>::emplace(Residue(residue));
   res.m_chain = this;
   return res;
 }
@@ -285,7 +285,7 @@ Chain& Frame::emplace(ChainName name, int reserve) {
 }
 
 Chain& Frame::emplace(const Chain& chain) {
-  auto& c = Container<Chain>::emplace(chain);
+  auto& c = Container<Chain>::emplace(Chain(chain));
   c.m_frame = this;
   return c;
 }

--- a/tests/polymer/Atom.cpp
+++ b/tests/polymer/Atom.cpp
@@ -338,12 +338,24 @@ TEST_F(AtomTests, access_after_resize){
   Frame frame = make_polyglycines({{"A",1}});
 
   auto chain_a = ElementReference<Atom>(frame.asAtoms()[0]);
-  auto& res = chain_a->residue();
-  chain_a->residue().emplace(*chain_a.get());
+  auto& res = ((Atom&)(chain_a)).residue();
+  ((Atom&)(chain_a)).residue().emplace((Atom&)(chain_a));
   auto chain_b = ElementReference<Atom>(frame.asAtoms()[0]);
 
-  EXPECT_EQ(chain_a.get(),chain_b.get());
+  EXPECT_EQ(((Atom&) chain_a),((Atom&) chain_b));
 //  EXPECT_NO_THROW(std::cout << chain_b.size());
 //  EXPECT_EQ(chain_b.size(),chain_2.size());
+
+}
+
+
+TEST_F(AtomTests, refcount_2){
+  Frame frame (0);
+  auto c = ElementReference<Chain>(frame.emplace(ChainName("A")));
+  c = ElementReference<Chain>(frame.emplace(ChainName("A")));
+  c = ElementReference<Chain>(frame.emplace(ChainName("A")));
+  c = ElementReference<Chain>(frame.emplace(ChainName("A")));
+  c = ElementReference<Chain>(frame.emplace(ChainName("A")));
+  c = ElementReference<Chain>(frame.emplace(ChainName("A")));
 
 }

--- a/tests/polymer/Atom.cpp
+++ b/tests/polymer/Atom.cpp
@@ -333,3 +333,17 @@ TEST_F(AtomTests, deletion_invalidates_selections_2){
   EXPECT_ANY_THROW(for (auto&a: atoms){});
   EXPECT_NO_THROW(for (auto&a: atoms-atoms_to_delete){});
 }
+
+TEST_F(AtomTests, access_after_resize){
+  Frame frame = make_polyglycines({{"A",1}});
+
+  auto chain_a = ElementReference<Atom>(frame.asAtoms()[0]);
+  auto& res = chain_a->residue();
+  chain_a->residue().emplace(*chain_a.get());
+  auto chain_b = ElementReference<Atom>(frame.asAtoms()[0]);
+
+  EXPECT_EQ(chain_a.get(),chain_b.get());
+//  EXPECT_NO_THROW(std::cout << chain_b.size());
+//  EXPECT_EQ(chain_b.size(),chain_2.size());
+
+}


### PR DESCRIPTION
Atom, Residue and Chain references are wrapped in thin smart pointer. 
If user access destroyed object via such pointer an exception raised (used to be sudden segfault).